### PR TITLE
worked around a zsh bug

### DIFF
--- a/bin/lpass-env
+++ b/bin/lpass-env
@@ -58,7 +58,7 @@ print_vars() {
 }
 
 export_vars() {
-	lpass show --notes "$KEY_NAME" | awk '{ print "export", $0 }'
+	lpass show --notes "$KEY_NAME" | sed -z 's/^/export /; s/\n/ /g'
 }
 
 


### PR DESCRIPTION
 ZSH would add a random `export=` after the second variable exported if there were more than 2 lines in a note.