### PR TITLE
Support empty and commented lines

### DIFF
--- a/bin/lpass-env
+++ b/bin/lpass-env
@@ -49,7 +49,7 @@ invalid_action() {
 
 launch_shell() {
 	echo "[lpass-env] Launching shell with environment from: $KEY_NAME"
-	$(lpass show --notes "$KEY_NAME" | awk '{ print "export", $0 }')
+	$(lpass show --notes "$KEY_NAME" | sed -E "/^(#.*)*$/d" | awk '{ print "export", $0 }')
 	PS1="lpass-env[$KEY_NAME]:\W \u\$ " bash
 }
 
@@ -58,7 +58,7 @@ print_vars() {
 }
 
 export_vars() {
-	lpass show --notes "$KEY_NAME" | awk '{ print "export", $0 }'
+	lpass show --notes "$KEY_NAME" | sed -E "/^(#.*)*$/d" | awk '{ print "export", $0 }'
 }
 
 


### PR DESCRIPTION
I wanted to be able to do:

```shell
# Common vars

## Application 1
MY_VAR=something
MY_VAR2=somethingelse

## Application 2
MY_VAR=something
MY_VAR2=somethingelse
```

`| sed -E "/^(#.*)*$/d"` will strip out the empty or commented lines.